### PR TITLE
feat: serialize `undefined` at top level

### DIFF
--- a/src/async.test.ts
+++ b/src/async.test.ts
@@ -13,6 +13,7 @@ import {
 	serverResource,
 	sleep,
 	waitError,
+	withDebug,
 } from "./test.utils.js";
 
 test("serialize async iterable", async () => {
@@ -25,9 +26,7 @@ test("serialize async iterable", async () => {
 		})(),
 	});
 
-	const iterable = serializeAsync(source(), {
-		serializers,
-	});
+	const iterable = serializeAsync(source());
 
 	const aggregate = await aggregateAsyncIterable(iterable);
 
@@ -66,22 +65,12 @@ test("serialize async iterable", async () => {
 		  [
 		    1,
 		    2,
-		    {
-		      "json": {
-		        "_": "$",
-		        "type": "undefined",
-		      },
-		    },
+		    {},
 		  ],
 		  [
 		    2,
 		    2,
-		    {
-		      "json": {
-		        "_": "$",
-		        "type": "undefined",
-		      },
-		    },
+		    {},
 		  ],
 		]
 	`);
@@ -206,6 +195,27 @@ test("stringify async generator", async () => {
 			]
 		`);
 	expect(stringifyAggregate.ok).toBe(true);
+});
+
+test("serialize + deserialize async generator returning undefined", async () => {
+	const source = () => ({
+		asyncIterable: (async function* () {
+			yield "a";
+			yield "b";
+			yield undefined;
+		})(),
+	});
+
+	const serialized = serializeAsync(source());
+
+	const parsed = await deserializeAsync(serialized);
+
+	const aggregate = await aggregateAsyncIterable(parsed.asyncIterable);
+
+	expect(aggregate.error).toBeUndefined();
+	expect(aggregate.ok).toBe(true);
+	expect(aggregate.items).toEqual(["a", "b", undefined]);
+	expect(aggregate.return).toBeUndefined();
 });
 
 test("serialize and parse", async () => {
@@ -506,6 +516,35 @@ test("async over the wire", async () => {
 		expect(aggregate.items).toEqual(["hello", "world"]);
 		expect(aggregate.return).toEqual("returned async iterable");
 	}
+});
+
+test("interrupted stream", async () => {
+	const source = () => ({
+		asyncIterable: (async function* () {
+			yield "hello";
+			yield "world";
+		})(),
+	});
+	type Source = ReturnType<typeof source>;
+	const iterable = stringifyAsync(source());
+
+	const result = await parseAsync<Source>(
+		(async function* () {
+			let chunkIndex = 0;
+			for await (const chunk of iterable) {
+				chunkIndex++;
+				if (chunkIndex > 2) {
+					return;
+				}
+				yield chunk;
+			}
+		})(),
+	);
+
+	const aggregate = await aggregateAsyncIterable(result.asyncIterable);
+
+	expect(aggregate.error).toBeInstanceOf(Error);
+	expect(aggregate.error).toMatchInlineSnapshot(`[Error: Stream interrupted]`);
 });
 
 test("dedupe", async () => {

--- a/src/async.test.ts
+++ b/src/async.test.ts
@@ -13,7 +13,6 @@ import {
 	serverResource,
 	sleep,
 	waitError,
-	withDebug,
 } from "./test.utils.js";
 
 test("serialize async iterable", async () => {

--- a/src/async.ts
+++ b/src/async.ts
@@ -289,9 +289,6 @@ export async function deserializeAsync<T>(
 							break;
 						case ASYNC_ITERABLE_STATUS_ERROR:
 							throw value;
-						default:
-							// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-							throw new Error(`Unknown async iterable status: ${status}`);
 					}
 				},
 			});
@@ -323,9 +320,6 @@ export async function deserializeAsync<T>(
 							return value;
 						case PROMISE_STATUS_REJECTED:
 							throw value;
-						default:
-							// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-							throw new Error(`Unknown promise status: ${status}`);
 					}
 				}
 			})();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest";
+
+import { deserializeSync, serializeSync } from "./index.js";
+
+test("smoke test", () => {
+	const value = {
+		bar: 1,
+		foo: "bar",
+	};
+	const serialized = serializeSync(value);
+	const deserialized = deserializeSync(serialized);
+	expect(deserialized).toEqual(value);
+});

--- a/src/mergeAsyncIterable.test.ts
+++ b/src/mergeAsyncIterable.test.ts
@@ -122,3 +122,25 @@ test("failed cleanup", async () => {
 		]
 	`);
 });
+
+test("cannot iterate twice", async () => {
+	const merged = mergeAsyncIterables<string>();
+
+	merged.add(
+		(async function* () {
+			yield "a";
+			yield "b";
+			yield "c";
+		})(),
+	);
+
+	// First iteration
+	await merged[Symbol.asyncIterator]().next();
+
+	const error = await waitError(async () => {
+		const newIterator = merged[Symbol.asyncIterator]();
+		await newIterator.next();
+	}, Error);
+
+	expect(error).toMatchInlineSnapshot(`[Error: Cannot iterate twice]`);
+});

--- a/src/std.test.ts
+++ b/src/std.test.ts
@@ -122,13 +122,14 @@ describe("TypedArray", () => {
 });
 
 test("undefined", () => {
-	const value = undefined;
+	const value = {
+		foo: undefined,
+	};
 	const str = stringify(value);
 
-	// eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
 	const deserialized = parse(str);
 
-	expect(deserialized).toBe(value);
+	expect(deserialized).toEqual(value);
 });
 
 describe("number", () => {

--- a/src/std.test.ts
+++ b/src/std.test.ts
@@ -129,6 +129,7 @@ test("undefined", () => {
 
 	const deserialized = parse(str);
 
+	expect(deserialized).toHaveProperty("foo", undefined);
 	expect(deserialized).toEqual(value);
 });
 

--- a/src/sync.test.ts
+++ b/src/sync.test.ts
@@ -375,7 +375,9 @@ test("stringify custom type", () => {
 });
 
 test("serialize/deserialize undefined", () => {
-	const source = undefined;
+	const source = {
+		foo: undefined,
+	};
 
 	const obj = serializeSync(source, {
 		serializers,
@@ -383,13 +385,14 @@ test("serialize/deserialize undefined", () => {
 	expect(obj).toMatchInlineSnapshot(`
 		{
 		  "json": {
-		    "_": "$",
-		    "type": "undefined",
+		    "foo": {
+		      "_": "$",
+		      "type": "undefined",
+		    },
 		  },
 		}
 	`);
 
-	// eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
 	const result = deserializeSync<typeof source>(obj, {
 		deserializers,
 	});
@@ -441,4 +444,15 @@ describe("magic types", () => {
 
 		expectTypeOf(result).toEqualTypeOf<typeof source>();
 	});
+});
+
+test("serialize/deserialize undefined at top level", () => {
+	const source = undefined;
+
+	const obj = serializeSync(source);
+	expect(obj).toEqual({});
+
+	// eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+	const result = deserializeSync(obj);
+	expect(result).toEqual(source);
 });

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -87,6 +87,9 @@ function isSubPath(path: Path, subPath: Path): boolean {
  * @returns An object containing the serialized JSON and any references
  */
 export function serializeSync<T>(value: T, options: SerializeOptions = {}) {
+	if (value === undefined) {
+		return {} as Serialized<SerializeReturn, T>;
+	}
 	type Location = [parent: JsonArray | JsonObject, key: number | string] | null;
 
 	const values = new Map<unknown, [Index, Location, Path]>();
@@ -234,7 +237,7 @@ export function serializeSync<T>(value: T, options: SerializeOptions = {}) {
 }
 
 export interface SerializeReturn {
-	json: JsonValue;
+	json?: JsonValue;
 	refs?: RefRecord;
 }
 
@@ -325,6 +328,9 @@ export function deserializeSync<T>(
 	obj: Serialized<SerializeReturn, T> | SerializeReturn,
 	options: DeserializeOptions = {},
 ): T {
+	if (obj.json === undefined) {
+		return undefined as T;
+	}
 	const deserializers = options.deserializers ?? {};
 	const cache = options.internal?.cache ?? new Map<RefLikeString, unknown>();
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		clearMocks: true,
 		coverage: {
 			all: true,
+			exclude: ["**/test.*.ts", "**/*.bench.ts"],
 			include: ["src"],
 			reporter: ["html", "lcov"],
 		},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 		clearMocks: true,
 		coverage: {
 			all: true,
-			exclude: ["**/test.*.ts", "**/*.bench.ts"],
+			exclude: ["**/test.*.ts", "**/*.bench.ts", "**/*.test.ts"],
 			include: ["src"],
 			reporter: ["html", "lcov"],
 		},


### PR DESCRIPTION
helps async iterables not needing the `undefined` serializer